### PR TITLE
Fixed issue where codes wouldn't generate + other fixes

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -2,6 +2,7 @@
 import json
 import secrets
 import time
+import sys
 from pprint import pformat
 from typing import Any, Tuple
 
@@ -291,7 +292,7 @@ def try_codes(driver: Driver, config: Config) -> None:
                             make_new_code = False
                         case "POST /auth/reset [400]":
                             logger.critical(f"{code_status_msg}: The reset token has expired. Please create a new reset token and update it in account.yml")
-                            quit
+                            sys.exit()
                         case _:
                             # fmt:off
                             logger.error(f"Encountered unimplemented status message. Tell the developers about this: {code_status_msg}")
@@ -314,4 +315,5 @@ def try_codes(driver: Driver, config: Config) -> None:
 
 def print_session_statistics(SessionStats):
     logger.info("\n" + pformat(SessionStats))
+
 


### PR DESCRIPTION
I have made some changes to the backend.py file where it should more reliably get codes. When I ran the code initially, the program would keep submitting the same 6 digit code or same backup code into the authenticator box. This should be fixed now. I also changed how it gets to the authenticator code or backup code pages as it would crash if I didn't quickly access those pages by myself. It should automatically try and get you to those pages. Also, whenever a user gets a POST AUTH 400 error, the program should quit now as the reset token has expired. Also, some users were having an issue with the 10 second pause for backup codes, which should be fixed in my update.

I haven't tried if it breaks if a user never set up a passkey. I left your existing code to check if there is a box to input codes as just plain text, as it seemed to break other users trying to access codes. If it does show up with just the authenticator code box, I would recommend changing what I have below.

People have been having issues with needing to complete the Captcha before the code tries to move on. If you can get the captcha to appear (for some reason it doesn't happen to me), please change line 149 with a different class ID similar to the format used on lines 214 & 215.