### PR TITLE
fix(backend): disable password save prompts in browser (again)

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -87,7 +87,14 @@ def bootstrap_browser(config: Config) -> Tuple[Driver, Config]:
 
             opts = ChromeOptions()
             opts.add_argument("--lang=en-US")
-            opts.add_experimental_option("prefs", {"credentials_enable_service": False})
+            # Options to disable password save prompt
+            opts.add_experimental_option(
+                "prefs",
+                {
+                    "credentials_enable_service": False,
+                    "profile": {"password_manager_enabled": False},
+                },
+            )
             if config.program.headless:
                 opts.add_argument("--log-level=1")
             # fmt: off


### PR DESCRIPTION
Fixs last error at [Issue #256](https://github.com/Derpitron/Discord-OTP-Forcer/issues/256) so the program doesn't crash because the password save prompt covers the buttons for the script that tries to click on the button.